### PR TITLE
[3129] Add execution of tests to pipeline

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -313,6 +313,8 @@ stages:
             value: $[ dependencies.AppInfraDev.outputs['AppInfraDev.tfoutputs.app_insights_instrumentation_key'] ]
           - name: namespace
             value: "$(Environment.ShortName)-${{ variables.domain }}"
+          - name: BASEURL
+            value: http://test.url
         strategy:
           runOnce:
             deploy:

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -26,7 +26,8 @@ resources:
     - repository: templates
       type: github
       name: amido/stacks-pipeline-templates
-      ref: refs/tags/v2.0.1
+      ref: 2cd597a49ccf6092e240e9ec628e25f7f110dde1 
+      # refs/tags/v2.0.1
       # EXCHANGE THIS FOR YOUR OWN ENDPOINT CONNECTION TO GITHUB
       # REPOSITORY IS PUBLIC
       endpoint: amidostacks
@@ -387,22 +388,6 @@ stages:
                     azure_client_secret: $(ARM_CLIENT_SECRET)
                     azure_tenant_id: $(ARM_TENANT_ID)
                     azure_subscription_id: $(ARM_SUBSCRIPTION_ID)
-
-                # Run the functional tests
-                # download the artefacts
-                - task: DownloadPipelineArtifact@2
-                  displayName: Download Functional Tests
-                  inputs:
-                    artifact: 'tests'
-                    path: $(Pipeline.Workspace)/tests
-
-                - task: DotNetCoreCLI@2
-                  displayName: "Test: Run Functional Tests"
-                  inputs:
-                    command: test
-                    testRunTitle: "Functional Tests"
-                    projects: $(Pipeline.Workspace)/tests
-                    arguments: "-v n"
 
   - stage: Prod
     dependsOn: Build

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -26,8 +26,7 @@ resources:
     - repository: templates
       type: github
       name: amido/stacks-pipeline-templates
-      ref: 6ec2b2c612f625f812ba81cfb3a9026b818f7524
-      # refs/tags/v2.0.1
+      ref: refs/tags/v2.0.2
       # EXCHANGE THIS FOR YOUR OWN ENDPOINT CONNECTION TO GITHUB
       # REPOSITORY IS PUBLIC
       endpoint: amidostacks
@@ -393,7 +392,7 @@ stages:
 
   - stage: Prod
     dependsOn: Build
-    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -369,7 +369,7 @@ stages:
                     scripts_dir: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
                     test_artefact: "tests"
                     test_baseurl: ""
-                    functional_test: false
+                    functional_test: true
                     performance_test: false
                     smoke_test: false
                     # Kubernetes Config
@@ -387,6 +387,22 @@ stages:
                     azure_client_secret: $(ARM_CLIENT_SECRET)
                     azure_tenant_id: $(ARM_TENANT_ID)
                     azure_subscription_id: $(ARM_SUBSCRIPTION_ID)
+
+                # Run the functional tests
+                # download the artefacts
+                - task: DownloadPipelineArtifact@2
+                  displayName: Download Functional Tests
+                  inputs:
+                    artifact: 'tests'
+                    path: $(Pipeline.Workspace)/tests
+
+                - task: DotNetCoreCLI@2
+                  displayName: "Test: Run Functional Tests"
+                  inputs:
+                    command: test
+                    testRunTitle: "Functional Tests"
+                    projects: $(Pipeline.Workspace)/tests
+                    arguments: "-v n"
 
   - stage: Prod
     dependsOn: Build

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -393,7 +393,7 @@ stages:
 
   - stage: Prod
     dependsOn: Build
-    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    # condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     variables:
       - group: amido-stacks-infra-credentials-prod
       - group: stacks-credentials-prod-kv
@@ -545,6 +545,8 @@ stages:
             value: $[ dependencies.AppInfraProd.outputs['AppInfraProd.tfoutputs.app_insights_instrumentation_key'] ]
           - name: namespace
             value: "$(Environment.ShortName)-${{ variables.domain }}"
+          - name: BASEURL
+            value: "https://$(Environment.ShortName)-$(domain).$(base_domain_nonprod)/api/menu/"
         strategy:
           runOnce:
             deploy:
@@ -602,7 +604,7 @@ stages:
                     scripts_dir: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
                     test_artefact: "tests"
                     test_baseurl: ""
-                    functional_test: false
+                    functional_test: true
                     performance_test: false
                     smoke_test: false
                     # Kubernetes Config

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -26,7 +26,7 @@ resources:
     - repository: templates
       type: github
       name: amido/stacks-pipeline-templates
-      ref: 2cd597a49ccf6092e240e9ec628e25f7f110dde1 
+      ref: 6ec2b2c612f625f812ba81cfb3a9026b818f7524 
       # refs/tags/v2.0.1
       # EXCHANGE THIS FOR YOUR OWN ENDPOINT CONNECTION TO GITHUB
       # REPOSITORY IS PUBLIC

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -195,6 +195,7 @@ stages:
               test_arguments: "-v q /p:CollectCoverage=true /p:CoverletOutputFormat=opencover"
               functional_test: true
               functional_test_artefact: tests
+              repo_name: $(self_repo)
               project_root_dir: $(Pipeline.Workspace)/s/$(self_repo)/$(self_repo_src)
 
   - stage: Dev

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -546,7 +546,7 @@ stages:
           - name: namespace
             value: "$(Environment.ShortName)-${{ variables.domain }}"
           - name: BASEURL
-            value: "https://$(Environment.ShortName)-$(domain).$(base_domain_nonprod)/api/menu/"
+            value: "https://$(Environment.ShortName)-$(domain).$(base_domain_prod)/api/menu/"
         strategy:
           runOnce:
             deploy:

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -26,7 +26,7 @@ resources:
     - repository: templates
       type: github
       name: amido/stacks-pipeline-templates
-      ref: 6ec2b2c612f625f812ba81cfb3a9026b818f7524 
+      ref: 6ec2b2c612f625f812ba81cfb3a9026b818f7524
       # refs/tags/v2.0.1
       # EXCHANGE THIS FOR YOUR OWN ENDPOINT CONNECTION TO GITHUB
       # REPOSITORY IS PUBLIC

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -193,6 +193,7 @@ stages:
                 BROKER_URL: $(PACT_BROKER)
               }
               test_arguments: "-v q /p:CollectCoverage=true /p:CoverletOutputFormat=opencover"
+              functional_test_artefact: tests
               project_root_dir: $(Pipeline.Workspace)/s/$(self_repo)/$(self_repo_src)
 
   - stage: Dev

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -314,7 +314,7 @@ stages:
           - name: namespace
             value: "$(Environment.ShortName)-${{ variables.domain }}"
           - name: BASEURL
-            value: http://test.url
+            value: "https://$(Environment.ShortName)-$(domain).$(base_domain_nonprod)/api/menu/"
         strategy:
           runOnce:
             deploy:

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -193,6 +193,7 @@ stages:
                 BROKER_URL: $(PACT_BROKER)
               }
               test_arguments: "-v q /p:CollectCoverage=true /p:CoverletOutputFormat=opencover"
+              functional_test: true
               functional_test_artefact: tests
               project_root_dir: $(Pipeline.Workspace)/s/$(self_repo)/$(self_repo_src)
 

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -161,7 +161,8 @@ steps:
         displayName: Build Functional Tests
         inputs:
           command: build
-          arguments: -o ${{ parameters.functional_test_path }} $(Build.SourcesDirectory)/$(repo_name)/src/tests/Functional
+          arguments: -o ${{ parameters.functional_test_path }}
+          workingDirectory: $(Build.SourcesDirectory)/${{ parameters.repo_name }}/src/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -160,7 +160,7 @@ steps:
         displayName: Build Functional Tests
         inputs:
           command: build
-          arguments: -o ${{ parameters.functional_test_path }} $(Build.SourcesDirectory)/src/tests/Functional
+          arguments: -o ${{ parameters.functional_test_path }} $(Build.SourcesDirectory)/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.sln
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -161,8 +161,7 @@ steps:
         displayName: Build Functional Tests
         inputs:
           command: build
-          arguments: -o ${{ parameters.functional_test_path }}
-          workingDirectory: $(Build.SourcesDirectory)/$(repo_name)/src/tests/Functional
+          arguments: -o ${{ parameters.functional_test_path }} $(Build.SourcesDirectory)/$(repo_name)/src/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -155,19 +155,16 @@ steps:
           docker_imagetag: ${{ parameters.docker_imagetag }}
           docker_containerregistryname: ${{ parameters.docker_containerregistryname }}
 
-  # Build functional tests
+  # Build and push functional tests
   - ${{ if eq(parameters.functional_test, true) }}:
       - task: DotNetCoreCLI@2
         displayName: Build Functional Tests
         inputs:
           command: build
-          arguments: -o ${{ parameters.functional_test_path }}
           workingDirectory: $(Build.SourcesDirectory)/${{ parameters.repo_name }}/src/tests/Functional
 
-  # Publish Artefacts if required
-  - ${{ if eq(parameters.functional_test, true) }}:
       - task: PublishPipelineArtifact@1
         displayName: "Publish: Functional Tests Artifact"
         inputs:
-          path: "${{ parameters.functional_test_path }}"
+          path: "$(Build.SourcesDirectory)/${{ parameters.repo_name }}/src/tests/Functional"
           artifact: "${{ parameters.functional_test_artefact }}"

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -154,25 +154,14 @@ steps:
           docker_imagetag: ${{ parameters.docker_imagetag }}
           docker_containerregistryname: ${{ parameters.docker_containerregistryname }}
 
-  - bash: which dotnet
-
-  - task: UseDotNet@2
-    displayName: 'Use .NET Core SDK ${{ parameters.dotnet_core_version }}'
-    inputs:
-      packageType: sdk
-      version: ${{ parameters.dotnet_core_version }}
-      installationPath: $(Agent.ToolsDirectory)/dotnet
-
-  - bash: which dotnet
-
   # Build functional tests
   - ${{ if eq(parameters.functional_test, true) }}:
       - task: DotNetCoreCLI@2
         displayName: Build Functional Tests
+        workingDirectory: src/api/tests/Functional
         inputs:
           command: build
           arguments: -o ${{ parameters.functional_test_path }}
-          workingDirectory: src/api/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -154,7 +154,8 @@ steps:
           docker_imagetag: ${{ parameters.docker_imagetag }}
           docker_containerregistryname: ${{ parameters.docker_containerregistryname }}
 
-  - bash: ls -l $(Build.SourcesDirectory)/src/tests/Functional
+  - bash: ls -l $(Build.SourcesDirectory)/
+  - bash: ls -l $(Build.SourcesDirectory)/src
 
   # Build functional tests
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -155,11 +155,11 @@ steps:
 
   # Build functional tests
   - ${{ if eq(parameters.functional_test, true) }}:
-    - task: DotNetCoreCLI@2
-      displayName: Build Functional Tests
-      inputs:
-        command: build
-        arguments: -o ${{ parameters.functional_test_path }} src/api/tests/Functional
+      - task: DotNetCoreCLI@2
+        displayName: Build Functional Tests
+        inputs:
+          command: build
+          arguments: -o ${{ parameters.functional_test_path }} src/api/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -162,7 +162,7 @@ steps:
         inputs:
           command: build
           arguments: -o ${{ parameters.functional_test_path }}
-          workingDir: $(Build.SourcesDirectory)/$(repo_name)/src/tests/Functional
+          workingDirectory: $(Build.SourcesDirectory)/$(repo_name)/src/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -27,6 +27,7 @@ parameters:
   contract_test: false
   contract_test_env: {}
   test_arguments: ""
+  repo_name: ""
   functional_test: false
   functional_test_path: $(Build.SourcesDirectory)/output/functional_tests
   functional_test_artefact: ""
@@ -154,16 +155,14 @@ steps:
           docker_imagetag: ${{ parameters.docker_imagetag }}
           docker_containerregistryname: ${{ parameters.docker_containerregistryname }}
 
-  - bash: ls -l $(Build.SourcesDirectory)/
-  - bash: ls -l $(Build.SourcesDirectory)/src
-
   # Build functional tests
   - ${{ if eq(parameters.functional_test, true) }}:
       - task: DotNetCoreCLI@2
         displayName: Build Functional Tests
         inputs:
           command: build
-          arguments: -o ${{ parameters.functional_test_path }} $(Build.SourcesDirectory)/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests.sln
+          arguments: -o ${{ parameters.functional_test_path }}
+          workingDir: $(Build.SourcesDirectory)/$(repo_name)/src/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -160,7 +160,8 @@ steps:
         displayName: Build Functional Tests
         inputs:
           command: build
-          arguments: -o ${{ parameters.functional_test_path }} src/api/tests/Functional
+          arguments: -o ${{ parameters.functional_test_path }}
+          workingDirectory: src/api/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -27,6 +27,7 @@ parameters:
   contract_test: false
   contract_test_env: {}
   test_arguments: ""
+  functional_test: false
   functional_test_path: $(Build.SourcesDirectory)/output/functional_tests
   functional_test_artefact: ""
 

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -154,6 +154,17 @@ steps:
           docker_imagetag: ${{ parameters.docker_imagetag }}
           docker_containerregistryname: ${{ parameters.docker_containerregistryname }}
 
+  - bash: which dotnet
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK ${{ parameters.dotnet_core_version }}'
+    inputs:
+      packageType: sdk
+      version: ${{ parameters.dotnet_core_version }}
+      installationPath: $(Agent.ToolsDirectory)/dotnet
+
+  - bash: which dotnet
+
   # Build functional tests
   - ${{ if eq(parameters.functional_test, true) }}:
       - task: DotNetCoreCLI@2

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -161,7 +161,7 @@ steps:
         inputs:
           command: build
           arguments: -o ${{ parameters.functional_test_path }}
-          workingDirectory: $(Build.SourcesDirectory)/src/api/tests/Functional
+          workingDirectory: $(Build.SourcesDirectory)/src/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -154,6 +154,8 @@ steps:
           docker_imagetag: ${{ parameters.docker_imagetag }}
           docker_containerregistryname: ${{ parameters.docker_containerregistryname }}
 
+  - bash: ls -l $(Build.SourcesDirectory)/src/tests/Functional
+
   # Build functional tests
   - ${{ if eq(parameters.functional_test, true) }}:
       - task: DotNetCoreCLI@2

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -160,8 +160,7 @@ steps:
         displayName: Build Functional Tests
         inputs:
           command: build
-          arguments: -o ${{ parameters.functional_test_path }}
-          workingDirectory: $(Build.SourcesDirectory)/src/tests/Functional
+          arguments: -o ${{ parameters.functional_test_path }} $(Build.SourcesDirectory)/src/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -27,6 +27,8 @@ parameters:
   contract_test: false
   contract_test_env: {}
   test_arguments: ""
+  functional_test_path: $(Build.SourcesDirectory)/output/functional_tests
+  functional_test_artefact: ""
 
 steps:
   # Login to Azure/AKS
@@ -150,6 +152,14 @@ steps:
           docker_imagename: ${{ parameters.docker_imagename }}
           docker_imagetag: ${{ parameters.docker_imagetag }}
           docker_containerregistryname: ${{ parameters.docker_containerregistryname }}
+
+  # Build functional tests
+  - ${{ if eq(parameters.functional_test, true) }}:
+    - task: DotNetCoreCLI@2
+      displayName: Build Functional Tests
+      inputs:
+        command: build
+        arguments: -o ${{ parameters.functional_test_path }} src/api/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:

--- a/build/azDevOps/azure/templates/steps/build/build-netcore.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-netcore.yml
@@ -158,10 +158,10 @@ steps:
   - ${{ if eq(parameters.functional_test, true) }}:
       - task: DotNetCoreCLI@2
         displayName: Build Functional Tests
-        workingDirectory: src/api/tests/Functional
         inputs:
           command: build
           arguments: -o ${{ parameters.functional_test_path }}
+          workingDirectory: $(Build.SourcesDirectory)/src/api/tests/Functional
 
   # Publish Artefacts if required
   - ${{ if eq(parameters.functional_test, true) }}:


### PR DESCRIPTION
📲 What

Re-enabled the functional tests within the build

🤔 Why

After the app has been deployed it needs to be tested.
The functional tests exists but have been disabled for a while. 

🛠 How

The tests are now being built in the `build-netcore.yml` and then copied as an artifact to Azure DevOps.

Updated the `deploy-k8s-app-kubectl.yml` file in the `stacks-pipeline-templates` repo so that the functional tests are downloaded and executed. The main template file sets an environment variable for the `BASEURL` which the tests use to hit the deployed application.

Some of the other CosmoDB variables for TF have had to be left in as the module requires these values even when CosmosDB is not being deployed.

👀 Evidence

All the tests are running and passing

🕵️ How to test

Test as normal
✅ Acceptance criteria Checklist

Code peer reviewed?
Documentation has been updated to reflect the changes?
Passing all automated tests, including a successful deployment?
Passing any exploratory testing?
Rebased/merged with latest changes from development and re-tested?
Meeting the Coding Standards?