### PR TITLE
Added missing map

### DIFF
--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/Controllers/Menu/GetMenuByIdController.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/Controllers/Menu/GetMenuByIdController.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel.DataAnnotations;
+using System.Linq;
 using System.Threading.Tasks;
 using Amido.Stacks.Application.CQRS.Queries;
 using Microsoft.AspNetCore.Authorization;
@@ -45,7 +46,29 @@ namespace xxAMIDOxx.xxSTACKSxx.API.Controllers
             if (result == null)
                 return NotFound();
 
-            return new ObjectResult(result);
+            var menu = new Menu
+            {
+                Id = result.Id,
+                Name = result.Name,
+                Description = result.Description,
+                Categories = result.Categories.Select(i => new Category()
+                {
+                    Id = i.Id,
+                    Name = i.Name,
+                    Description = i.Description,
+                    Items = i.Items.Select(x => new Item()
+                    {
+                        Id = x.Id,
+                        Name = x.Name,
+                        Description = x.Description,
+                        Price = x.Price,
+                        Available = x.Available
+                    }).ToList(),
+                }).ToList(),
+                Enabled = result.Enabled
+            };
+
+            return new ObjectResult(menu);
         }
     }
 }


### PR DESCRIPTION
Add response mapping from query result to model response in controller

📲 What
Currently, the response returned by the controller is q query result model. This change is to map the query result model to a response model in the controller.

🤔 Why
This is required as the existing controller should return a response model.

🕵️ How to test
These changes are covered by existing unit tests.

✅ Acceptance criteria Checklist
 Code peer reviewed?
 Documentation has been updated to reflect the changes?
 Passing all automated tests, including a successful deployment?
 Passing any exploratory testing?
 Rebased/merged with latest changes from development and re-tested?
 Meeting the Coding Standards?