### PR TITLE
[3301] Update pipeline to create GitHub release artifact

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -50,6 +50,7 @@
 				"_rels/**",
 				"package/**",
 				"**/*.nuspec",
+				"**/[Tt]emplate.csproj",
 				"*Content_Types*.xml"
 			],
 			"rename": {

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -117,6 +117,7 @@ stages:
           - template: templates/steps/build/build-and-release-packages.yml
             parameters:
               root_src_dir: $(Agent.BuildDirectory)/s
+              package_version: $(version_major).$(version_minor).$(version_revision)
 
   - stage: Build
     variables:

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -161,7 +161,7 @@ stages:
               workingDirectory: $(Agent.BuildDirectory)/s/$(self_repo)
               script: |
                 git config --global user.email "russell.seymour@turtlesystems.co.uk"
-                git config --global user.name russellseymour
+                git config --global user.name "russellseymour"
                 git tag -a v${BUILD_BUILDNUMBER} -m "Release created by Azure DevOps"
                 git push --tags
 

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -134,7 +134,7 @@ stages:
 
             env:
               ROOT_SRC_DIR: $(Agent.BuildDirectory)/s
-              REPO_NAME: ${{ parameters.repo_name }}       
+              REPO_NAME: $(self_repo)
 
           # Call template to build the package from the templates dir
           - template: azDevOps/azure/templates/v2/steps/build-dotnet-package.yml@templates

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -137,10 +137,17 @@ stages:
               REPO_NAME: $(self_repo)
 
           # Call template to build the package from the templates dir
-          - template: azDevOps/azure/templates/v2/steps/build-dotnet-package.yml@templates
+          - template: azDevOps/azure/templates/v2/steps/build-pack-test-dotnet.yml@templates
             parameters:
               package_path: $(Agent.BuildDirectory)/s
               dotnet_core_version: 3.1.x
+
+          # Upload the packages as artefacts
+          - task: PublishPipelineArtifact@1
+            display: Publish Templates
+            inputs:
+              path: $(Agent.BuildDirectory)/s/$(self_repo)/bin/Release
+              artifact: packages
 
           # Call the template to create the packages
           #- template: templates/steps/build/build-and-release-packages.yml

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -633,4 +633,3 @@ stages:
           - template: templates/steps/build/build-and-release-packages.yml
             parameters:
               root_src_dir: $(Agent.BuildDirectory)/s
-                    

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -146,7 +146,7 @@ stages:
           - task: PublishPipelineArtifact@1
             displayName: Publish Templates
             inputs:
-              path: $(Agent.BuildDirectory)/s/$(self_repo)/bin/Release
+              path: $(Agent.BuildDirectory)/s/bin/Release
               artifact: packages
 
           # Call the template to create the packages

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -109,6 +109,10 @@ stages:
           vmImage: $(pool_vm_image)
         steps:
 
+          - checkout: self
+
+          - checkout: templates
+
           # Call the template to create the packages
           - template: templates/steps/build/build-and-release-packages.yml
             parameters:

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -105,76 +105,6 @@ variables:
   github_org: $(company)
 
 stages:
-  - stage: Release
-    jobs:
-      - job: CreatePackages
-        pool:
-          vmImage: $(pool_vm_image)
-        steps:
-
-          - checkout: self
-
-          - checkout: templates
-
-          # Updates the build number in Azure DevOps (requires refresh in the UI to see)
-          - bash: |
-              echo '##vso[build.updatebuildnumber]${{ variables.docker_image_tag }}'
-            displayName: 'Update: Build Number'          
-
-          # Copy the files into the correct place for packaging
-          - task: Bash@3
-            displayName: Prepare for Packaging
-            inputs:
-              targetType: "inline"
-              workingDirectory: $(Agent.BuildDirectory)/s
-              script: |
-                cp $REPO_NAME/template.csproj .
-                mkdir ./templates
-                pushd templates
-                cp -r ${ROOT_SRC_DIR}/$REPO_NAME .
-                cp -r ${ROOT_SRC_DIR}/$REPO_NAME/src/api .
-                popd
-
-            env:
-              ROOT_SRC_DIR: $(Agent.BuildDirectory)/s
-              REPO_NAME: $(self_repo)
-
-          # Call template to build the package from the templates dir
-          - template: azDevOps/azure/templates/v2/steps/build-pack-test-dotnet.yml@templates
-            parameters:
-              package_path: $(Agent.BuildDirectory)/s
-              dotnet_core_version: 3.1.x
-
-          # Upload the packages as artefacts
-          - task: PublishPipelineArtifact@1
-            displayName: Publish Templates
-            inputs:
-              path: $(Agent.BuildDirectory)/a
-              artifact: packages
-
-          # Tag the code with the build number to create a snapshot which can
-          # be cloned
-          - task: Bash@3
-            displayName: Tag Code
-            inputs:
-              targetType: "inline"
-              workingDirectory: $(Agent.BuildDirectory)/s/$(self_repo)
-              script: |
-                git config --global user.email "russell.seymour@turtlesystems.co.uk"
-                git config --global user.name "russellseymour"
-                git tag -a v${BUILD_BUILDNUMBER} -m "Release created by Azure DevOps"
-                git push --tags
-
-          # # Create a GitHub release with the packages
-          # - task: GitHubRelease@0
-          #   displayName: Create GitHub Release
-          #   inputs:
-          #     gitHubConnection: $(github_release_service_connection)
-          #     repositoryName: $(github_org)/$(self_repo)
-          #     tag: $(Build.BuildNumber)
-          #     assets: |
-          #       $(Agent.BuildDirectory)/a/*.nupkg
-
   - stage: Build
     variables:
       - group: amido-stacks-infra-credentials-nonprod
@@ -270,6 +200,37 @@ stages:
               functional_test_artefact: tests
               repo_name: $(self_repo)
               project_root_dir: $(Pipeline.Workspace)/s/$(self_repo)/$(self_repo_src)
+
+          # Copy the files into the correct place for packaging
+          - task: Bash@3
+            displayName: Prepare for Packaging
+            inputs:
+              targetType: "inline"
+              workingDirectory: $(Agent.BuildDirectory)/s
+              script: |
+                cp $REPO_NAME/template.csproj .
+                mkdir ./templates
+                pushd templates
+                cp -r ${ROOT_SRC_DIR}/$REPO_NAME .
+                cp -r ${ROOT_SRC_DIR}/$REPO_NAME/src/api .
+                popd
+
+            env:
+              ROOT_SRC_DIR: $(Agent.BuildDirectory)/s
+              REPO_NAME: $(self_repo)
+
+          # Call template to build the package from the templates dir
+          - template: azDevOps/azure/templates/v2/steps/build-pack-test-dotnet.yml@templates
+            parameters:
+              package_path: $(Agent.BuildDirectory)/s
+              dotnet_core_version: 3.1.x
+
+          # Upload the packages as artefacts
+          - task: PublishPipelineArtifact@1
+            displayName: Publish Templates
+            inputs:
+              path: $(Agent.BuildDirectory)/a
+              artifact: packages
 
   - stage: Dev
     dependsOn: Build
@@ -695,3 +656,29 @@ stages:
                     azure_tenant_id: $(ARM_TENANT_ID)
                     azure_subscription_id: $(ARM_SUBSCRIPTION_ID)
 
+  - stage: Release
+    dependsOn: Build
+    condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    jobs:
+      - job: CreateGitHubRelease
+        pool:
+          vmImage: $(pool_vm_image)
+        steps:
+          # Check out the repo so that it can be tagged
+          - checkout: self
+
+          # Download the artefacts from the build to create the release from
+          - task: DownloadPipelineArtifact@2
+            inputs:
+              artifact: 'packages'
+              path: $(System.DefaultWorkingDirectory)/packages
+
+          # Create a GitHub release with these packages
+          - task: GitHubRelease@0
+            displayName: Create GitHub Release
+            inputs:
+              gitHubConnection: $(github_release_service_connection)
+              repositoryName: $(github_org)/$(self_repo)
+              tag: $(Build.BuildNumber)
+              assets: |
+                $(System.DefaultWorkingDirectory)/packages/*.nupkg

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -100,6 +100,9 @@ variables:
   # Yamllint
   yamllint_config_file: "${{ variables.self_repo_dir }}/yamllint.conf"
   yamllint_scan_directory: "."
+  # Release
+  github_release_service_connection: GitHubReleases
+  github_org: $(company)
 
 stages:
   - stage: Release
@@ -149,11 +152,26 @@ stages:
               path: $(Agent.BuildDirectory)/a
               artifact: packages
 
-          # Call the template to create the packages
-          #- template: templates/steps/build/build-and-release-packages.yml
-          #  parameters:
-          #    root_src_dir: $(Agent.BuildDirectory)/s
-          #    package_version: $(version_major).$(version_minor).$(version_revision)
+          # Tag the code with the build number to create a snapshot which can
+          # be cloned
+          - task: Bash@3
+            displayName: Tag Code
+            inputs:
+              targetType: "inline"
+              workingDirectory: $(Agent.BuildDirectory)/s/$(self_repo)
+              script: |
+                git tag -a v${BUILD_BUILDNUMBER} -m "Release created by Azure DevOps"
+                git push --tags
+
+          # # Create a GitHub release with the packages
+          # - task: GitHubRelease@0
+          #   displayName: Create GitHub Release
+          #   inputs:
+          #     gitHubConnection: $(github_release_service_connection)
+          #     repositoryName: $(github_org)/$(self_repo)
+          #     tag: $(Build.BuildNumber)
+          #     assets: |
+          #       $(Agent.BuildDirectory)/a/*.nupkg
 
   - stage: Build
     variables:

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -102,6 +102,18 @@ variables:
   yamllint_scan_directory: "."
 
 stages:
+  - stage: Release
+    jobs:
+      - job: CreatePackages
+        pool:
+          vmImage: $(pool_vm_image)
+        steps:
+
+          # Call the template to create the packages
+          - template: templates/steps/build/build-and-release-packages.yml
+            parameters:
+              root_src_dir: $(Agent.BuildDirectory)/s
+
   - stage: Build
     variables:
       - group: amido-stacks-infra-credentials-nonprod
@@ -622,15 +634,3 @@ stages:
                     azure_tenant_id: $(ARM_TENANT_ID)
                     azure_subscription_id: $(ARM_SUBSCRIPTION_ID)
 
-  - stage: Release
-    condition: not(failed('Build'))
-    jobs:
-      - job: CreatePackages
-        pool:
-          vmImage: $(pool_vm_image)
-        steps:
-
-          # Call the template to create the packages
-          - template: templates/steps/build/build-and-release-packages.yml
-            parameters:
-              root_src_dir: $(Agent.BuildDirectory)/s

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -144,7 +144,7 @@ stages:
 
           # Upload the packages as artefacts
           - task: PublishPipelineArtifact@1
-            display: Publish Templates
+            displayName: Publish Templates
             inputs:
               path: $(Agent.BuildDirectory)/s/$(self_repo)/bin/Release
               artifact: packages

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -113,11 +113,40 @@ stages:
 
           - checkout: templates
 
-          # Call the template to create the packages
-          - template: templates/steps/build/build-and-release-packages.yml
+          # Updates the build number in Azure DevOps (requires refresh in the UI to see)
+          - bash: |
+              echo '##vso[build.updatebuildnumber]${{ variables.docker_image_tag }}'
+            displayName: 'Update: Build Number'          
+
+          # Copy the files into the correct place for packaging
+          - task: Bash@3
+            displayName: Prepare for Packaging
+            inputs:
+              targetType: "inline"
+              workingDirectory: $(Agent.BuildDirectory)/s
+              script: |
+                cp $REPO_NAME/template.csproj .
+                mkdir ./templates
+                pushd templates
+                cp -r ${ROOT_SRC_DIR}/$REPO_NAME .
+                cp -r ${ROOT_SRC_DIR}/$REPO_NAME/src/api .
+                popd
+
+            env:
+              ROOT_SRC_DIR: $(Agent.BuildDirectory)/s
+              REPO_NAME: ${{ parameters.repo_name }}       
+
+          # Call template to build the package from the templates dir
+          - template: azDevOps/azure/templates/v2/steps/build-dotnet-package.yml@templates
             parameters:
-              root_src_dir: $(Agent.BuildDirectory)/s
-              package_version: $(version_major).$(version_minor).$(version_revision)
+              package_path: $(Agent.BuildDirectory)/s
+              dotnet_core_version: 3.1.x
+
+          # Call the template to create the packages
+          #- template: templates/steps/build/build-and-release-packages.yml
+          #  parameters:
+          #    root_src_dir: $(Agent.BuildDirectory)/s
+          #    package_version: $(version_major).$(version_minor).$(version_revision)
 
   - stage: Build
     variables:

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -142,19 +142,11 @@ stages:
               package_path: $(Agent.BuildDirectory)/s
               dotnet_core_version: 3.1.x
 
-          - task: Bash@3
-            inputs:
-              targetType: "inline"
-              workingDirectory: $(Agent.BuildDirectory)/a
-              script: |
-                ls -l
-                find . -name *.nupkg
-
           # Upload the packages as artefacts
           - task: PublishPipelineArtifact@1
             displayName: Publish Templates
             inputs:
-              path: $(Agent.BuildDirectory)/s/bin/Release
+              path: $(Agent.BuildDirectory)/a
               artifact: packages
 
           # Call the template to create the packages

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -160,6 +160,8 @@ stages:
               targetType: "inline"
               workingDirectory: $(Agent.BuildDirectory)/s/$(self_repo)
               script: |
+                git config --global user.email "russell.seymour@turtlesystems.co.uk"
+                git config --global user.name russellseymour
                 git tag -a v${BUILD_BUILDNUMBER} -m "Release created by Azure DevOps"
                 git push --tags
 

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -142,6 +142,14 @@ stages:
               package_path: $(Agent.BuildDirectory)/s
               dotnet_core_version: 3.1.x
 
+          - task: Bash@3
+            inputs:
+              targetType: "inline"
+              workingDirectory: $(Agent.BuildDirectory)/s
+              script: |
+                ls -l
+                find . -name *.nupkg
+
           # Upload the packages as artefacts
           - task: PublishPipelineArtifact@1
             displayName: Publish Templates

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -621,3 +621,16 @@ stages:
                     azure_client_secret: $(ARM_CLIENT_SECRET)
                     azure_tenant_id: $(ARM_TENANT_ID)
                     azure_subscription_id: $(ARM_SUBSCRIPTION_ID)
+
+  - stage: Release
+    jobs:
+      - job: CreatePackages
+        pool:
+          vmImage: $(pool_vm_image)
+        steps:
+
+          # Call the template to create the packages
+          - template: templates/steps/build/build-and-release-packages.yml
+            parameters:
+              root_src_dir: $(Agent.BuildDirectory)/s
+                    

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -657,7 +657,9 @@ stages:
                     azure_subscription_id: $(ARM_SUBSCRIPTION_ID)
 
   - stage: Release
-    dependsOn: Build
+    dependsOn:
+      - Build
+      - Prod
     condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     jobs:
       - job: CreateGitHubRelease

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -668,12 +668,22 @@ stages:
         steps:
           # Check out the repo so that it can be tagged
           - checkout: self
+            persistCredentials: true
 
           # Download the artefacts from the build to create the release from
           - task: DownloadPipelineArtifact@2
             inputs:
               artifact: 'packages'
               path: $(System.DefaultWorkingDirectory)/packages
+
+          # Create a tag in the code for this release
+          - task: Bash@3
+            displayName: Tag Code
+            inputs:
+              targetType: "inline"
+              script: |
+                git tag -a v${BUILD_BUILDNUMBER} -m "Release created by Azure DevOps"
+                git push origin v${BUILD_BUILDNUMBER}
 
           # Create a GitHub release with these packages
           - task: GitHubRelease@0

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -145,7 +145,7 @@ stages:
           - task: Bash@3
             inputs:
               targetType: "inline"
-              workingDirectory: $(Agent.BuildDirectory)/s
+              workingDirectory: $(Agent.BuildDirectory)/a
               script: |
                 ls -l
                 find . -name *.nupkg

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -623,6 +623,7 @@ stages:
                     azure_subscription_id: $(ARM_SUBSCRIPTION_ID)
 
   - stage: Release
+    condition: not(failed('Build')
     jobs:
       - job: CreatePackages
         pool:

--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -623,7 +623,7 @@ stages:
                     azure_subscription_id: $(ARM_SUBSCRIPTION_ID)
 
   - stage: Release
-    condition: not(failed('Build')
+    condition: not(failed('Build'))
     jobs:
       - job: CreatePackages
         pool:

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -29,13 +29,6 @@ steps:
         cp -r ${ROOT_SRC_DIR}/$REPO_NAME/src/api .
         popd
 
-        # Clean up the copy to remove git and terraform files
-        pushd ${ROOT_SRC_DIR}/${REPO_NAME}
-        ls -la
-        rm -rf .git .github .terraform
-        ls -la
-        popd
-
         # Perform the packing of the templates
         dotnet pack -p:PackageVersion=${VERSION} -o output/packages
     env:

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -35,7 +35,7 @@ steps:
         popd
 
         # Perform the packing of the templates
-        dotent pack -p:PackageVersion=${BUILD_BUILDNUMBER} -o output/packages
+        dotnet pack -p:PackageVersion=${BUILD_BUILDNUMBER} -o output/packages
     env:
       ROOT_SRC_DIR: $(Agent.BuildDirectory)/s
       REPO_NAME: ${{ parameters.repo_name }}

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -4,6 +4,7 @@ parameters:
   root_src_dir: ""
   repo_name: stacks-dotnet-cqrs
   dotnet_core_version: "3.1.x"
+  package_version: ""
 
 steps:
 
@@ -35,10 +36,11 @@ steps:
         popd
 
         # Perform the packing of the templates
-        dotnet pack -p:PackageVersion=${BUILD_BUILDNUMBER} -o output/packages
+        dotnet pack -p:PackageVersion=${VERSION} -o output/packages
     env:
       ROOT_SRC_DIR: $(Agent.BuildDirectory)/s
       REPO_NAME: ${{ parameters.repo_name }}
+      VERSION: ${{ parameters.package_version }}
 
   # Upload the packages as artifacts
   - task: PublishPipelineArtifact@1

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -1,0 +1,39 @@
+parameters:
+  pool:
+    vmImage: "ubuntu-latest"
+  root_src_dir: ""
+  repo_name: stacks-dotnet-cqrs-events
+
+steps:
+  # Build Nuget packages for templates
+  - task: Bash@3
+    displayName: Create Packages
+    inputs:
+      targetType: "inline"
+      workingDirectory: $(root_src_dir)
+      script: |
+        cp $REPO_NAME/template.csproj
+        mkdir ./templates
+        pushd templates
+        cp -r ${ROOT_SRC_DIR}/$REPO_NAME .
+        cp -r ${ROOT_SRC_DIR}/$REPO_NAME/src/api .
+        popd
+
+        # Clean up the copy to remove git and terraform files
+        pushd ${ROOT_SRC_DIR}/${REPO_NAME}
+        rm -f .git .github .terraform
+        popd
+
+        # Perform the packing of the templates
+        dotent pack -p:PackageVersion=${BUILD_BUILDNUMBER} -o output/packages
+    env:
+      ROOT_SRC_DIR: $(Agent.BuildDirectory)/s
+      REPO_NAME: $(self_repo)
+
+  # Upload the packages as artifacts
+  - task: PublishPipelineArtifact@1
+    displayName: "Publish: NuGet Packages"
+    inputs:
+      path: $(root_src_dir)/output/packages
+      artifact: packages
+  

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -33,7 +33,7 @@ steps:
         pushd ${ROOT_SRC_DIR}/${REPO_NAME}
         ls -la
         rm -rf .git .github .terraform
-        ls -l a
+        ls -la
         popd
 
         # Perform the packing of the templates

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -22,7 +22,6 @@ steps:
       targetType: "inline"
       workingDirectory: ${{ parameters.root_src_dir }}
       script: |
-        ls -l
         cp $REPO_NAME/template.csproj .
         mkdir ./templates
         pushd templates
@@ -32,9 +31,9 @@ steps:
 
         # Clean up the copy to remove git and terraform files
         pushd ${ROOT_SRC_DIR}/${REPO_NAME}
-        ls -l
+        ls -la
         rm -rf .git .github .terraform
-        ls -l 
+        ls -l a
         popd
 
         # Perform the packing of the templates

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -22,7 +22,7 @@ steps:
       workingDirectory: ${{ parameters.root_src_dir }}
       script: |
         ls -l
-        cp $REPO_NAME/template.csproj
+        cp $REPO_NAME/template.csproj .
         mkdir ./templates
         pushd templates
         cp -r ${ROOT_SRC_DIR}/$REPO_NAME .

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -10,7 +10,7 @@ steps:
     displayName: Create Packages
     inputs:
       targetType: "inline"
-      workingDirectory: $(root_src_dir)
+      workingDirectory: ${{ parameters.root_src_dir }}
       script: |
         cp $REPO_NAME/template.csproj
         mkdir ./templates
@@ -28,11 +28,11 @@ steps:
         dotent pack -p:PackageVersion=${BUILD_BUILDNUMBER} -o output/packages
     env:
       ROOT_SRC_DIR: $(Agent.BuildDirectory)/s
-      REPO_NAME: $(self_repo)
+      REPO_NAME: ${{ parameters.repo_name }}
 
   # Upload the packages as artifacts
   - task: PublishPipelineArtifact@1
     displayName: "Publish: NuGet Packages"
     inputs:
-      path: $(root_src_dir)/output/packages
+      path: ${{ parameters.root_src_dir }}/output/packages
       artifact: packages

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -36,4 +36,3 @@ steps:
     inputs:
       path: $(root_src_dir)/output/packages
       artifact: packages
-  

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -32,7 +32,9 @@ steps:
 
         # Clean up the copy to remove git and terraform files
         pushd ${ROOT_SRC_DIR}/${REPO_NAME}
+        ls -l
         rm -rf .git .github .terraform
+        ls -l 
         popd
 
         # Perform the packing of the templates

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -2,9 +2,18 @@ parameters:
   pool:
     vmImage: "ubuntu-latest"
   root_src_dir: ""
-  repo_name: stacks-dotnet-cqrs-events
+  repo_name: stacks-dotnet-cqrs
+  dotnet_core_version: "3.1.x"
 
 steps:
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET Core SDK ${{ parameters.dotnet_core_version }}'
+    inputs:
+      packageType: sdk
+      version: ${{ parameters.dotnet_core_version }}
+      installationPath: $(Agent.ToolsDirectory)/dotnet
+
   # Build Nuget packages for templates
   - task: Bash@3
     displayName: Create Packages
@@ -12,6 +21,7 @@ steps:
       targetType: "inline"
       workingDirectory: ${{ parameters.root_src_dir }}
       script: |
+        ls -l
         cp $REPO_NAME/template.csproj
         mkdir ./templates
         pushd templates

--- a/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
+++ b/build/azDevOps/azure/templates/steps/build/build-and-release-packages.yml
@@ -31,7 +31,7 @@ steps:
 
         # Clean up the copy to remove git and terraform files
         pushd ${ROOT_SRC_DIR}/${REPO_NAME}
-        rm -f .git .github .terraform
+        rm -rf .git .github .terraform
         popd
 
         # Perform the packing of the templates

--- a/src/api/.template.config/template.json
+++ b/src/api/.template.config/template.json
@@ -62,6 +62,7 @@
                 "_rels/**",
                 "package/**",
                 "**/*.nuspec",
+                "**/[Tt]emplate.csproj",
                 "*Content_Types*.xml"
             ],
             "modifiers": []

--- a/template.csproj
+++ b/template.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-  	<Content Include=".\templates\**" Exclude=".\.git\**;.\.github\**;.\.vscode\**;.\obj;.\bin;.\template.csproj" />
+  	<Content Include=".\templates\**" Exclude=".\templates\.git\**;.\templates\.github\**;.\templates\.vscode\**;.\obj;.\bin;.\templates\template.csproj" />
     <Compile Remove="**\*" />
   </ItemGroup>
 

--- a/template.csproj
+++ b/template.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-  	<Content Include=".\templates\**" Exclude=".\templates\**\.git\**;.\templates\**\.github\**;.\templates\**\.vscode\**;.\templates\**\obj;.\templates\**\bin;.\templates\**\template.csproj" />
+  	<Content Include=".\templates\**" Exclude=".\templates\**\.git\**;.\templates\**\.github\**;.\templates\**\.vscode\**;.\templates\**\obj\**;.\templates\**\bin\**;.\templates\**\template.csproj" />
     <Compile Remove="**\*" />
   </ItemGroup>
 

--- a/template.csproj
+++ b/template.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-  	<Content Include=".\templates\**" Exclude=".\templates\.git\**;.\templates\.github\**;.\templates\.vscode\**;.\obj;.\bin;.\templates\template.csproj" />
+  	<Content Include=".\templates\**" Exclude=".\templates\**\.git\**;.\templates\**\.github\**;.\templates\**\.vscode\**;.\templates\**\obj;.\templates\**\bin;.\templates\**\template.csproj" />
     <Compile Remove="**\*" />
   </ItemGroup>
 

--- a/template.csproj
+++ b/template.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-  	<Content Include=".\templates\**" Exclude=".\templates\**\.git\**;.\templates\**\.github\**;.\templates\**\.vscode\**;.\templates\**\obj\**;.\templates\**\bin\**;.\templates\**\template.csproj" />
+  	<Content Include=".\templates\**" Exclude=".\templates\**\.git\**;.\templates\**\.github\**;.\templates\**\.vscode\**;.\templates\**\obj\**;.\templates\**\bin\**;.\templates\**\.terraform\**;.\templates\**\.store\**;.\templates\**\template.csproj" />
     <Compile Remove="**\*" />
   </ItemGroup>
 


### PR DESCRIPTION
📲 What

Add a steps and a stage to create a release for the Nuget templates

🤔 Why

So that people can use our expertise and add components to existing projects we have created a Nuget package of templates. The build now creates these and will create a release when created from master.

🛠 How

Added new steps to the build stage that create the Nuget packages from the `template.csproj`. These are then uploaded as a build artefact.
At the end of the run and if the build has run from `master` it will create a new GitHub release with the artefact and tag the code.

👀 Evidence

Nuget files are being added as aretfacts

✅ Acceptance criteria Checklist

Code peer reviewed?
Documentation has been updated to reflect the changes?
Passing all automated tests, including a successful deployment?
Passing any exploratory testing?
Rebased/merged with latest changes from development and re-tested?
Meeting the Coding Standards?