### PR TITLE
[3454] Names of the docker images are incorrect

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -54,7 +54,7 @@ variables:
   self_repo_dir: "$(Agent.BuildDirectory)/s/$(self_repo)"
   self_repo_tf_src: deploy/azure/app/kube
   self_repo_tf_dir: "$(self_repo_dir)/$(self_repo_tf_src)"
-  self_generic_name: stacks-api
+  self_generic_name: stacks-api-cqrs
   self_pipeline_repo: "$(Agent.BuildDirectory)/s/stacks-pipeline-templates"
   self_pipeline_scripts_dir: "$(self_pipeline_repo)/scripts"
   # TF STATE CONFIG


### PR DESCRIPTION
📲 What

Ensure that the name of the Document container image is unique to the project

🤔 Why

During the split out of the different projects, the name of the Docker container image was not updated. This meant that three projects `stacks-dotnet`, `stacks-dotnet-cqrs` and `stacks-dotnet-cqrs-events` were all using the same image name of `stacks-api`.

When a build occurred for a project the image was being built and published and then deployed.
However if a deployment of another project occured, without a build, then the latest version of the container would be deployed, which would have been from a different project build. This meant that code for events, for example, could end up being deployed into the environment for just cqrs.

🛠 How

Changed the value of the `self-generic-name` to ensure the docker container is named correctly.

👀 Evidence

Containers are now being added to the registry in the correct repository.

![image](https://user-images.githubusercontent.com/791658/130429441-760a1e11-9b97-4a09-8d15-5a6e15781ba4.png)
