### PR TITLE
Fix URL for functional tests

### DIFF
--- a/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
+++ b/build/azDevOps/azure/azure-pipelines-netcore-k8s.yml
@@ -26,7 +26,7 @@ resources:
     - repository: templates
       type: github
       name: amido/stacks-pipeline-templates
-      ref: refs/tags/v2.0.3
+      ref: refs/tags/v2.0.4
       # EXCHANGE THIS FOR YOUR OWN ENDPOINT CONNECTION TO GITHUB
       # REPOSITORY IS PUBLIC
       endpoint: amidostacks
@@ -104,7 +104,6 @@ variables:
   create_release: true
   github_release_service_connection: GitHubReleases
   github_org: $(company)
-  nuget_service_connection: NuGetAmidoStacksServiceConnection
 
 stages:
   - stage: Build
@@ -351,8 +350,6 @@ stages:
             value: $[ dependencies.AppInfraDev.outputs['AppInfraDev.tfoutputs.app_insights_instrumentation_key'] ]
           - name: namespace
             value: "$(Environment.ShortName)-${{ variables.domain }}"
-          - name: BASEURL
-            value: "https://$(Environment.ShortName)-$(domain).$(base_domain_nonprod)/api/menu/"
         strategy:
           runOnce:
             deploy:
@@ -405,11 +402,18 @@ stages:
                       }
                     ]
 
+                # Upload the deployment manifest as an artefact
+                - task: PublishPipelineArtifact@1
+                  displayName: Publish K8s Manifest
+                  inputs:
+                    path: $(self_repo_dir)/deploy/k8s/app/api-deploy.yml
+                    artifact: manifests_dev
+
                 - template: azDevOps/azure/templates/v2/steps/deploy-k8s-app-kubectl.yml@templates
                   parameters:
                     scripts_dir: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
                     test_artefact: "tests"
-                    test_baseurl: ""
+                    test_baseurl: "https://$(Environment.ShortName)-${{ variables.domain }}.$(base_domain_nonprod)/api/menu/"
                     functional_test: true
                     performance_test: false
                     smoke_test: false
@@ -583,8 +587,6 @@ stages:
             value: $[ dependencies.AppInfraProd.outputs['AppInfraProd.tfoutputs.app_insights_instrumentation_key'] ]
           - name: namespace
             value: "$(Environment.ShortName)-${{ variables.domain }}"
-          - name: BASEURL
-            value: "https://$(Environment.ShortName)-$(domain).$(base_domain_prod)/api/menu/"
         strategy:
           runOnce:
             deploy:
@@ -637,11 +639,18 @@ stages:
                       }
                     ]
 
+                # Upload the deployment manifest as an artefact
+                - task: PublishPipelineArtifact@1
+                  displayName: Publish K8s Manifest
+                  inputs:
+                    path: $(self_repo_dir)/deploy/k8s/app/api-deploy.yml
+                    artifact: manifests_prod
+
                 - template: azDevOps/azure/templates/v2/steps/deploy-k8s-app-kubectl.yml@templates
                   parameters:
                     scripts_dir: $(Agent.BuildDirectory)/s/stacks-pipeline-templates/azDevOps/azure/templates/v2/scripts
                     test_artefact: "tests"
-                    test_baseurl: ""
+                    test_baseurl: "https://$(Environment.ShortName)-${{ variables.domain }}.$(base_domain_prod)/api/menu/"
                     functional_test: true
                     performance_test: false
                     smoke_test: false


### PR DESCRIPTION
📲 What

Correct the URL that is used by the functional tests

🤔 Why

In the prod environment the tests were pointing to the dev environment

🛠 How

By updating the `stacks-pipeline-templates` to use the `tests_baseurl` the URL for the tests can now be overridden by setting this variable. Internally the value is set as `BaseUrl` environment variable which the tests will pick up.

👀 Evidence

The tests are passing and the URLs can be seen in the logs of the app.

The environment variable is being set in the pipeline:

![image](https://user-images.githubusercontent.com/791658/131379823-101b4f1b-6ecf-4760-bf46-2e9383702f89.png)


🕵️ How to test

Notes for QA
✅ Acceptance criteria Checklist

Code peer reviewed?
Documentation has been updated to reflect the changes?
Passing all automated tests, including a successful deployment?
Passing any exploratory testing?
Rebased/merged with latest changes from development and re-tested?
Meeting the Coding Standards?