### PR TITLE
Updated the baseURL and readme.

### DIFF
--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/ReadMe.md
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/ReadMe.md
@@ -1,6 +1,6 @@
 # Amido Stacks Automated Functional Testing
 
-The full documentation on Amido Stacks can be found [here](https://amido.github.io/stacks/).
+The full documentation on Amido Stacks can be found [here](https://github.com/amido/stacks-dotnet).
 
 Amido Stacks targets different cloud providers.
 

--- a/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/appsettings.json
+++ b/src/tests/Functional/xxAMIDOxx.xxSTACKSxx.API.FunctionalTests/appsettings.json
@@ -1,3 +1,3 @@
 {
-  "BaseUrl": "https://dev-netcore-api-cqrs.nonprod.amidostacks.com/api/menu/"
+  "BaseUrl": "http://localhost:5000/"
 }


### PR DESCRIPTION
-  Updated the base url in the app setting json in the functional test as the current one (amodo dev environment) does not work when a template version is used.

- Updated a correct URL in the ReadMe