### PR TITLE
3617 - Wrap cosmos DB into .Net CLI argument

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -1,75 +1,114 @@
 {
-	"$schema": "http://json.schemastore.org/template",
-	"author": "stacks@amido.com",
-	"classifications": [
-		"Stacks",
-		"WebAPI",
-		"CQRS",
-		"api"
-	],
-	"name": "Amido Stacks Web Api CQRS - Full solution",
-	"identity": "Amido.Stacks.App.WebApi.CQRS",
-	"shortName": "stacks-app-web-api-cqrs",
-	"tags": {
-		"language": "C#",
-		"type": "project"
-	},
-	"sourceName": "xxAMIDOxx.xxSTACKSxx",
-	"preferNameDirectory": true,
-	"symbols": {
-		"domain": {
-			"type": "parameter",
-			"isRequired": true,
-			"replaces": "Menu",
-			"fileRename": "Menu",
-			"defaultValue": "DOMAIN",
-			"forms": {
-				"global": [
-					"identity",
-					"lowerCase"
-				]
-			}
-		}
-	},
-	"sources": [
-		{
-			"source": "./",
-			"include": [
-				"**/*"
-			],
-			"exclude": [
-				"**/[Bb]in/**",
-				"**/[Oo]bj/**",
-				"**/.template.config/**",
-				"**/*.filelist",
-				"**/*.user",
-				"**/*.lock.json",
-				"**/.git/**",
-				"**/.vs/**",
-				"**/.vscode/**",
-				"_rels/**",
-				"package/**",
-				"**/*.nuspec",
-				"*Content_Types*.xml"
-			],
-			"rename": {
-				"_gitignore": ".gitignore",
-				"_gitattributes": ".gitattributes"
-			},
-			"modifiers": []
-		}
-	],
-	"SpecialCustomOperations": {
-		"**/*.yml": {
-			"Operations": [
-				{
-					"type": "conditional",
-					"configuration": {
-						"style": "line",
-						"token": "#"
-					}
-				}
-			]
-		}
-	}
+  "$schema": "http://json.schemastore.org/template",
+  "author": "stacks@amido.com",
+  "classifications": [
+    "Stacks",
+    "WebAPI",
+    "CQRS",
+    "api"
+  ],
+  "name": "Amido Stacks Web Api CQRS - Full solution",
+  "identity": "Amido.Stacks.App.WebApi.CQRS",
+  "shortName": "stacks-app-web-api-cqrs",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "xxAMIDOxx.xxSTACKSxx",
+  "preferNameDirectory": true,
+  "symbols": {
+    "domain": {
+      "type": "parameter",
+      "isRequired": true,
+      "replaces": "Menu",
+      "fileRename": "Menu",
+      "defaultValue": "DOMAIN",
+      "forms": {
+        "global": [
+          "identity",
+          "lowerCase"
+        ]
+      }
+    },
+    "database": {
+      "type": "parameter",
+      "datatype": "choice",
+      "choices": [
+        {
+          "choice": "CosmosDb",
+          "description": "Targets Azure Cosmos database for storing data."
+        },
+        {
+          "choice": "DynamoDb",
+          "description": "Targets AWS Dynamo database for storing data."
+        }
+      ],
+      "description": "Adds saving to database."
+    },
+    "CosmosDb": {
+      "type": "computed",
+      "value": "(database == \"CosmosDb\")"
+    },
+    "DynamoDb": {
+      "type": "computed",
+      "value": "(database == \"DynamoDb\")"
+    }
+  },
+  "sources": [
+    {
+      "source": "./",
+      "include": [
+        "**/*"
+      ],
+      "exclude": [
+        "**/[Bb]in/**",
+        "**/[Oo]bj/**",
+        "**/.template.config/**",
+        "**/*.filelist",
+        "**/*.user",
+        "**/*.lock.json",
+        "**/.git/**",
+        "**/.vs/**",
+        "**/.vscode/**",
+        "_rels/**",
+        "package/**",
+        "**/*.nuspec",
+        "*Content_Types*.xml"
+      ],
+      "rename": {
+        "_gitignore": ".gitignore",
+        "_gitattributes": ".gitattributes"
+      },
+      "modifiers": [
+        {
+          "condition": "(CosmosDb)",
+          "exclude": [
+            "**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/DynamoDbMenuRepository.cs",
+            "**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/DynamoDbMenuRepositoryTests.cs"
+          ]
+        },
+        {
+          "condition": "(DynamoDb)",
+          "exclude": [
+            "**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/CosmosDbMenuRepository.cs",
+            "**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/CosmosDbMenuRepositoryTests.cs"
+          ]
+        }
+      ]
+    }
+  ],
+
+  "SpecialCustomOperations": {
+    "**/*.yml": {
+      "Operations": [
+        {
+          "type": "conditional",
+          "configuration": {
+            "style": "line",
+            "token": "#"
+          }
+        }
+      ]
+    }
+  }
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.API/appsettings.json
@@ -32,6 +32,9 @@
             "Source": "Environment"
         }
     },
+    "DynamoDb": {
+
+    },
     "JwtBearerAuthentication": {
         "Audience": "<TODO>",
         "Authority": "<TODO>",

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/CosmosDbMenuRepositoryTests.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/CosmosDbMenuRepositoryTests.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Amido.Stacks.Configuration;
@@ -16,7 +16,6 @@ using xxAMIDOxx.xxSTACKSxx.Infrastructure.Repositories;
 
 namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests
 {
-
     /// <summary>
     /// The purpose of this integration test is to validate the implementation
     /// of MenuRepository againt the data store at development\integration
@@ -24,9 +23,9 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests
     /// Configuration issues will be surfaced on e2e or acceptance tests
     /// </summary>
     [Trait("TestType", "IntegrationTests")]
-    public class MenuRepositoryTests
+    public class CosmosDbMenuRepositoryTests
     {
-        public MenuRepositoryTests()
+        public CosmosDbMenuRepositoryTests()
         {
             var settings = Configuration.For<CosmosDbConfiguration>("CosmosDB");
             //Notes:
@@ -53,7 +52,7 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests
         /// the menu information and is retrieved properly
         /// </summary>
         [Theory, MenuRepositoryAutoData]
-        public async Task SaveAndGetTest(MenuRepository repository, Menu menu)
+        public async Task SaveAndGetTest(CosmosDbMenuRepository repository, Menu menu)
         {
             await repository.SaveAsync(menu);
             var dbItem = await repository.GetByIdAsync(menu.Id);
@@ -79,7 +78,7 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests
         /// removes an existing menu and is not retrieved when requested
         /// </summary>
         [Theory, MenuRepositoryAutoData]
-        public async Task DeleteTest(MenuRepository repository, Menu menu)
+        public async Task DeleteTest(CosmosDbMenuRepository repository, Menu menu)
         {
             await repository.SaveAsync(menu);
             var dbItem = await repository.GetByIdAsync(menu.Id);

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/DynamoDbMenuRepositoryTests.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/DynamoDbMenuRepositoryTests.cs
@@ -1,0 +1,19 @@
+﻿using Xunit;
+
+namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests
+{
+    /// <summary>
+    /// The purpose of this integration test is to validate the implementation
+    /// of MenuRepository againt the data store at development\integration
+    /// It is not intended to test if the configuration is valid for a release
+    /// Configuration issues will be surfaced on e2e or acceptance tests
+    /// </summary>
+    [Trait("TestType", "IntegrationTests")]
+    public class DynamoDbMenuRepositoryTests
+    {
+        public DynamoDbMenuRepositoryTests()
+        {
+
+        }
+    }
+}

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/appsettings.json
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/appsettings.json
@@ -1,4 +1,4 @@
-{
+﻿{
     "CosmosDb": {
         "DatabaseAccountUri": "https://localhost:8081/",
         "DatabaseName": "Stacks",
@@ -6,5 +6,8 @@
             "Identifier": "COSMOSDB_KEY",
             "Source": "Environment"
         }
+    },
+    "DynamoDb": {
+
     }
 }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Amido.Stacks.Application.CQRS.ApplicationEvents;
 using Amido.Stacks.Application.CQRS.Commands;
 using Amido.Stacks.Application.CQRS.Queries;
@@ -39,22 +39,28 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
         /// <param name="services"></param>
         public static void ConfigureProductionDependencies(WebHostBuilderContext context, IServiceCollection services)
         {
-            services.Configure<CosmosDbConfiguration>(context.Configuration.GetSection("CosmosDB"));
-
             services.AddSecrets();
+
+#if (CosmosDb)
+            services.Configure<CosmosDbConfiguration>(context.Configuration.GetSection("CosmosDB"));
             services.AddCosmosDB();
+            services.AddTransient<IMenuRepository, CosmosDbMenuRepository>();
+#elif (DynamoDb)
+            //services.Configure<DynamoDbConfiguration>(context.Configuration.GetSection("DynamoDb"));
+            //services.AddDynamoDB();
+            //services.AddTransient<IMenuRepository, DynamoDbMenuRepository>();
+#else
+            services.AddTransient<IMenuRepository, InMemoryMenuRepository>();
+#endif
 
             //TODO: Evaluate if event publishers should be generic, probably not, EventHandler are generic tough
             AddEventPublishers(services);
 
-            if (Environment.GetEnvironmentVariable("USE_MEMORY_STORAGE") == null)
-                services.AddTransient<IMenuRepository, MenuRepository>();
-            else
-                services.AddTransient<IMenuRepository, InMemoryMenuRepository>();
-
             var healthChecks = services.AddHealthChecks();
-            healthChecks.AddCheck<CosmosDbDocumentStorage<Menu>>("CosmosDB");
             healthChecks.AddCheck<CustomHealthCheck>("Sample");//This is a sample health check, remove if not needed, more info: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/monitor-app-health
+#if (CosmosDb)
+            healthChecks.AddCheck<CosmosDbDocumentStorage<Menu>>("CosmosDB");
+#endif
         }
 
         private static void AddCommandHandlers(IServiceCollection services)

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/DependencyRegistration.cs
@@ -57,8 +57,8 @@ namespace xxAMIDOxx.xxSTACKSxx.Infrastructure
             AddEventPublishers(services);
 
             var healthChecks = services.AddHealthChecks();
-            healthChecks.AddCheck<CustomHealthCheck>("Sample");//This is a sample health check, remove if not needed, more info: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/monitor-app-health
 #if (CosmosDb)
+            healthChecks.AddCheck<CustomHealthCheck>("Sample");//This is a sample health check, remove if not needed, more info: https://docs.microsoft.com/en-us/dotnet/architecture/microservices/implement-resilient-applications/monitor-app-health
             healthChecks.AddCheck<CosmosDbDocumentStorage<Menu>>("CosmosDB");
 #endif
         }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/CosmosDbMenuRepository.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/CosmosDbMenuRepository.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Threading.Tasks;
 using Amido.Stacks.Data.Documents.Abstractions;
 using xxAMIDOxx.xxSTACKSxx.Application.Integration;
@@ -6,11 +6,11 @@ using xxAMIDOxx.xxSTACKSxx.Domain;
 
 namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.Repositories
 {
-    public class MenuRepository : IMenuRepository
+    public class CosmosDbMenuRepository : IMenuRepository
     {
         readonly IDocumentStorage<Menu> documentStorage;
 
-        public MenuRepository(IDocumentStorage<Menu> documentStorage)
+        public CosmosDbMenuRepository(IDocumentStorage<Menu> documentStorage)
         {
             this.documentStorage = documentStorage;
         }

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/DynamoDbMenuRepository.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/DynamoDbMenuRepository.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Threading.Tasks;
+using xxAMIDOxx.xxSTACKSxx.Application.Integration;
+using xxAMIDOxx.xxSTACKSxx.Domain;
+
+namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.Repositories
+{
+    public class DynamoDbMenuRepository : IMenuRepository
+    {
+        public DynamoDbMenuRepository()
+        {
+        }
+
+        public async Task<Menu> GetByIdAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<bool> SaveAsync(Menu entity)
+        {
+            throw new NotImplementedException();
+        }
+
+        public async Task<bool> DeleteAsync(Guid id)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}
+


### PR DESCRIPTION
3617 - Wrap cosmos DB into .Net CLI argument

📲 What
Adding --database arguments to the .net templating to configure the project solution to use either CosmosDb/DynamoDb or InMemory database via the CLI.

🤔 Why
So that the user can set up cofniguration based on their selected database configuration. Not need to remove any unused and irrelevant code.

🛠 How
Achieved by using template arguments on c# pre processor directives within code.

👀 Evidence
Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

🕵️ How to test
Notes for QA

✅ Acceptance criteria Checklist
 Code peer reviewed?
 Documentation has been updated to reflect the changes?
 Passing all automated tests, including a successful deployment?
 Passing any exploratory testing?
 Rebased/merged with latest changes from development and re-tested?
 Meeting the Coding Standards?