### PR TITLE
Azure Service Bus Listener - Add new listener function

### DIFF
--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/StacksListenerTests.cs
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/StacksListenerTests.cs
@@ -51,7 +51,6 @@ public class StacksListenerTests
         logger.Received(1).LogInformation($"Message read. Menu Id: {message.MessageId}");
     }
 
-
     public MenuCreatedEvent BuildMessageBody()
     {
         var id = Guid.NewGuid();
@@ -85,7 +84,6 @@ public class StacksListenerTests
 
         return message;
     }
-
 
     private static Guid GetCorrelationId(object body)
     {

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/StacksListenerTests.cs
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener.UnitTests/StacksListenerTests.cs
@@ -16,17 +16,15 @@ namespace xxAMIDOxx.xxSTACKSxx.Listener.UnitTests;
 [Trait("TestType", "UnitTests")]
 public class StacksListenerTests
 {
-    private readonly IMessageReader msgReader;
     private readonly ILogger<StacksListener> logger;
 
     public StacksListenerTests()
     {
-        msgReader = Substitute.For<IMessageReader>();
         logger = Substitute.For<ILogger<StacksListener>>();
     }
 
     [Fact]
-    public void TestMessage()
+    public void TestRun()
     {
         var msgBody = BuildMessageBody();
         var message = BuildMessage(msgBody);
@@ -34,19 +32,6 @@ public class StacksListenerTests
         var stacksListener = new StacksListener(msgReader, logger);
 
         stacksListener.Run(message);
-
-        msgReader.Received(1).Read<StacksCloudEvent<MenuCreatedEvent>>(message);
-    }
-
-    [Fact]
-    public void TestReceiveMessage()
-    {
-        var msgBody = BuildMessageBody();
-        var message = BuildReceivedMessage(msgBody);
-
-        var stacksListener = new StacksListener(msgReader, logger);
-
-        stacksListener.ReceiveMessage(message);
 
         logger.Received(1).LogInformation($"Message read. Menu Id: {message.MessageId}");
     }
@@ -57,23 +42,7 @@ public class StacksListenerTests
         return new MenuCreatedEvent(new TestOperationContext(), id);
     }
 
-    public Message BuildMessage(MenuCreatedEvent body)
-    {
-        Guid correlationId = GetCorrelationId(body);
-
-        var convertedMessage = new Message
-        {
-            CorrelationId = $"{correlationId}",
-            ContentType = "application/json;charset=utf-8",
-            Body = Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(body))
-        };
-
-        return convertedMessage
-            .SetEnclosedMessageType(body.GetType())
-            .SetSerializerType(GetType());
-    }
-
-    public ServiceBusReceivedMessage BuildReceivedMessage(MenuCreatedEvent body)
+    public ServiceBusReceivedMessage BuildMessage(MenuCreatedEvent body)
     {
         Guid correlationId = GetCorrelationId(body);
 

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
@@ -1,7 +1,11 @@
-﻿using Amido.Stacks.Messaging.Azure.ServiceBus.Serializers;
+﻿using System;
+using System.Text;
+using Amido.Stacks.Messaging.Azure.ServiceBus.Serializers;
+using Azure.Messaging.ServiceBus;
 using Microsoft.Azure.ServiceBus;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using xxAMIDOxx.xxSTACKSxx.Application.CQRS.Events;
 
 namespace xxAMIDOxx.xxSTACKSxx.Listener;
@@ -17,7 +21,8 @@ public class StacksListener
         this.logger = logger;
     }
 
-    [FunctionName("StacksListener")]
+    [Obsolete("This Method is Deprecated. Please use StacksListener.ReceiveMessage()")]
+    [FunctionName("StacksListenerMessage")]
     public void Run([ServiceBusTrigger(
         "%TOPIC_NAME%",
         "%SUBSCRIPTION_NAME%",
@@ -30,4 +35,19 @@ public class StacksListener
 
         logger.LogInformation($"C# ServiceBus topic trigger function processed message: {appEvent}");
     }
+
+    [FunctionName("StacksListenerServiceBusReceivedMessage")]
+    public void ReceiveMessage([ServiceBusTrigger(
+        "%TOPIC_NAME%",
+        "%SUBSCRIPTION_NAME%",
+        Connection = "SERVICEBUS_CONNECTIONSTRING")] ServiceBusReceivedMessage mySbMsg)
+    {
+        var appEvent = JsonConvert.DeserializeObject<StacksCloudEvent<MenuCreatedEvent>>(Encoding.UTF8.GetString(mySbMsg.Body));
+
+        // TODO: work with appEvent
+        logger.LogInformation($"Message read. Menu Id: {appEvent?.Data?.MenuId}");
+
+        logger.LogInformation($"C# ServiceBus topic trigger function processed message: {appEvent}");
+    }
 }
+

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
@@ -21,9 +21,13 @@ public class StacksListener
         this.logger = logger;
     }
 
-    [Obsolete("This Method is Deprecated. Please use StacksListener.ReceiveMessage()")]
+    // This method is left here to show off the IMessageReader.Read<T>() from the ASB package - Amido.Stacks.Messaging.Azure.ServiceBus
+    // However, we advise against using it since the package is working with the old 'Message' type. A major refactor of the package is needed.
+    // New types from 'Azure.Messaging.ServiceBus' are 'ServiceBusMessage' and 'ServiceBusReceivedMessage'
+    // You can still send 'Message' types, but depending on the version of your function and the .NET SDK, you might need to receive it as 'ServiceBusReceivedMessage'
+    [Obsolete("This Method is Deprecated. Please use StacksListener.Run()")]
     [FunctionName("StacksListenerMessage")]
-    public void Run([ServiceBusTrigger(
+    public void RunMessage([ServiceBusTrigger(
         "%TOPIC_NAME%",
         "%SUBSCRIPTION_NAME%",
         Connection = "SERVICEBUS_CONNECTIONSTRING")] Message mySbMsg)
@@ -36,8 +40,8 @@ public class StacksListener
         logger.LogInformation($"C# ServiceBus topic trigger function processed message: {appEvent}");
     }
 
-    [FunctionName("StacksListenerServiceBusReceivedMessage")]
-    public void ReceiveMessage([ServiceBusTrigger(
+    [FunctionName("StacksListener")]
+    public void Run([ServiceBusTrigger(
         "%TOPIC_NAME%",
         "%SUBSCRIPTION_NAME%",
         Connection = "SERVICEBUS_CONNECTIONSTRING")] ServiceBusReceivedMessage mySbMsg)

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/StacksListener.cs
@@ -12,32 +12,11 @@ namespace xxAMIDOxx.xxSTACKSxx.Listener;
 
 public class StacksListener
 {
-    private readonly IMessageReader msgReader;
     private readonly ILogger<StacksListener> logger;
 
-    public StacksListener(IMessageReader msgReader, ILogger<StacksListener> logger)
+    public StacksListener(ILogger<StacksListener> logger)
     {
-        this.msgReader = msgReader;
         this.logger = logger;
-    }
-
-    // This method is left here to show off the IMessageReader.Read<T>() from the ASB package - Amido.Stacks.Messaging.Azure.ServiceBus
-    // However, we advise against using it since the package is working with the old 'Message' type. A major refactor of the package is needed.
-    // New types from 'Azure.Messaging.ServiceBus' are 'ServiceBusMessage' and 'ServiceBusReceivedMessage'
-    // You can still send 'Message' types, but depending on the version of your function and the .NET SDK, you might need to receive it as 'ServiceBusReceivedMessage'
-    [Obsolete("This Method is Deprecated. Please use StacksListener.Run()")]
-    [FunctionName("StacksListenerMessage")]
-    public void RunMessage([ServiceBusTrigger(
-        "%TOPIC_NAME%",
-        "%SUBSCRIPTION_NAME%",
-        Connection = "SERVICEBUS_CONNECTIONSTRING")] Message mySbMsg)
-    {
-        var appEvent = msgReader.Read<StacksCloudEvent<MenuCreatedEvent>>(mySbMsg);
-
-        // TODO: work with appEvent
-        logger.LogInformation($"Message read. Menu Id: {appEvent?.Data?.MenuId}");
-
-        logger.LogInformation($"C# ServiceBus topic trigger function processed message: {appEvent}");
     }
 
     [FunctionName("StacksListener")]

--- a/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/Startup.cs
+++ b/src/functions/func-asb-listener/xxAMIDOxx.xxSTACKSxx.Listener/Startup.cs
@@ -34,8 +34,6 @@ public class Startup : FunctionsStartup
             .Configure<StacksListener>(configuration.GetSection(nameof(StacksListener)))
             .AddLogging(l => { l.AddSerilog(CreateLogger(configuration)); })
             .AddTransient(typeof(ILogger<>), typeof(LogAdapter<>));
-
-        builder.Services.AddTransient<IMessageReader, JsonMessageSerializer>();
     }
 
     private static IConfiguration LoadConfiguration(IFunctionsHostBuilder builder)


### PR DESCRIPTION
[AB#4585](https://amido-dev.visualstudio.com/73884c9a-a68f-4f67-b2b5-b588c2eb8492/_workitems/edit/4585) Azure Service Bus Listener - Add new listener function

#### 📲 What

Azure Service Bus Listener - Add new listener function that consumes the new `ServiceBusReceivedMessage` type

#### 🤔 Why


#### 🛠 How

More in-depth discussion of the change or implementation.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
