### PR TITLE
BUGFIX:  Fixes function names for prod

### DIFF
--- a/build/azDevOps/azure/air-api.yml
+++ b/build/azDevOps/azure/air-api.yml
@@ -468,7 +468,7 @@ stages:
                     container_registry_name: $(docker_container_registry_name_nonprod)
                     function_image_name: $(docker_image_name_asb_listener)
                     function_image_tag: $(docker_image_tag)
-                    function_name: func-asb-listener-nwhujo # TODO: This name is constructed in TF but we currently have no way of reading the output into the pipeline
+                    function_name: func-asb-listener-oivgfd # TODO: This name is constructed in TF but we currently have no way of reading the output into the pipeline
                     function_resource_group: amido-stacks-prod-euw-netcore-api-cqrs # TODO: This name is constructed in TF but we currently have no way of reading the output into the pipeline
 
                 - template: templates/legacy-deploy-functions.yml
@@ -478,7 +478,7 @@ stages:
                     container_registry_name: $(docker_container_registry_name_nonprod)
                     function_image_name: $(docker_image_name_aeh_listener)
                     function_image_tag: $(docker_image_tag)
-                    function_name: func-aeh-listener-lngrjm # TODO: This name is constructed in TF but we currently have no way of reading the output into the pipeline
+                    function_name: func-aeh-listener-hoqaru # TODO: This name is constructed in TF but we currently have no way of reading the output into the pipeline
                     function_resource_group: amido-stacks-prod-euw-netcore-api-cqrs # TODO: This name is constructed in TF but we currently have no way of reading the output into the pipeline
 
                 - template: templates/legacy-deploy-functions.yml
@@ -487,6 +487,6 @@ stages:
                     container_registry_name: $(docker_container_registry_name_nonprod)
                     function_image_name: $(docker_image_name_worker)
                     function_image_tag: $(docker_image_tag)
-                    function_name: function-publisher-nwhujo # TODO: This name is constructed in TF but we currently have no way of reading the output into the pipeline
+                    function_name: function-publisher-oivgfd # TODO: This name is constructed in TF but we currently have no way of reading the output into the pipeline
                     function_resource_group: amido-stacks-prod-euw-netcore-api-cqrs # TODO: This name is constructed in TF but we currently have no way of reading the output into the pipeline
 


### PR DESCRIPTION
BUGFIX:  Fixes function names for prod

#### 📲 What

Updates function names for deployprod 

#### 🤔 Why


Function names are read post-hoc inside TaskCTL and as such are not pre-populated when they are rebuilt, this is populating their name. A backlog item exists to push this information out of TaskCTL and into ADO, and also to deploy containers via TaskCTL - so this is tactical bugfix.

#### 🛠 How

Reading from TF outputs and copying over to function job inputs.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
