### PR TITLE
Update templates to remove redundant tests

### DIFF
--- a/.template.config/template.json
+++ b/.template.config/template.json
@@ -226,6 +226,8 @@
 					"exclude": [
 						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/DynamoDbMenuRepository.cs",
 						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/DynamoDbMenuRepositoryTests.cs",
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/InMemoryMenuRepositoryTests.cs",
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/InMemoryMenuRepositoryAutoDataAttribute.cs",
 						"**/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/DynamoDbCategoryConverterTests.cs"
 					]
 				},
@@ -234,6 +236,8 @@
 					"exclude": [
 						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/CosmosDbMenuRepository.cs",
 						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/CosmosDbMenuRepositoryTests.cs",
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/InMemoryMenuRepositoryTests.cs",
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/InMemoryMenuRepositoryAutoDataAttribute.cs",
 						"**src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests/CosmosDbMenuRepositoryTests.cs",
 						"**/src/api/xxAMIDOxx.xxSTACKSxx.CQRS.UnitTests/HandlerTests.cs",
 						"**/src/api/xxAMIDOxx.xxSTACKSxx.API.ComponentTests/Fixtures/CreateCategoryFixture.cs",
@@ -247,7 +251,9 @@
 						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/CosmosDbMenuRepositoryTests.cs",
 						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure/Repositories/DynamoDbMenuRepository.cs",
 						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/DynamoDbMenuRepositoryTests.cs",
-						"**/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/DynamoDbCategoryConverterTests.cs"
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Domain.UnitTests/DynamoDbCategoryConverterTests.cs",
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests/CosmosDbMenuRepositoryTests.cs",
+						"**/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.UnitTests/DynamoDbMenuRepositoryTests.cs"
 					]
 				},
 				{

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/InMemoryMenuRepositoryAutoDataAttribute.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/InMemoryMenuRepositoryAutoDataAttribute.cs
@@ -1,0 +1,23 @@
+using AutoFixture;
+using AutoFixture.Xunit2;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using xxAMIDOxx.xxSTACKSxx.Infrastructure.Fakes;
+
+namespace xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests;
+
+public class InMemoryMenuRepositoryAutoDataAttribute : AutoDataAttribute
+{
+    public InMemoryMenuRepositoryAutoDataAttribute() : base(Customizations) { }
+
+    public static IFixture Customizations()
+    {
+        IFixture fixture = new Fixture();
+
+        var loggerFactory = Substitute.For<ILoggerFactory>();
+        loggerFactory.CreateLogger(Arg.Any<string>()).Returns(new Logger<InMemoryMenuRepository>(loggerFactory));
+        fixture.Register<ILogger<InMemoryMenuRepository>>(() => new Logger<InMemoryMenuRepository>(loggerFactory));
+
+        return fixture;
+    }
+}

--- a/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/InMemoryMenuRepositoryTests.cs
+++ b/src/api/xxAMIDOxx.xxSTACKSxx.Infrastructure.IntegrationTests/InMemoryMenuRepositoryTests.cs
@@ -1,6 +1,5 @@
 using System.Threading.Tasks;
 using AutoFixture;
-using AutoFixture.Xunit2;
 using Xunit;
 using Xunit.Abstractions;
 using xxAMIDOxx.xxSTACKSxx.Domain;
@@ -31,7 +30,7 @@ public class InMemoryMenuRepositoryTests
     /// Ensure the implementation of MenuRepository.Save() submit
     /// the menu information and is retrieved properly
     /// </summary>
-    [Theory, AutoData]
+    [Theory, InMemoryMenuRepositoryAutoData]
     public async Task SaveAndGetTest(InMemoryMenuRepository repository, Menu menu)
     {
         output.WriteLine($"Creating the menu '{menu.Id}' in the repository");
@@ -52,7 +51,7 @@ public class InMemoryMenuRepositoryTests
     /// Ensure the implementation of MenuRepository.Delete()
     /// removes an existing menu and is not retrieved when requested
     /// </summary>
-    [Theory, AutoData]
+    [Theory, InMemoryMenuRepositoryAutoData]
     public async Task DeleteTest(InMemoryMenuRepository repository, Menu menu)
     {
         output.WriteLine($"Creating the menu '{menu.Id}' in the repository");
@@ -71,7 +70,7 @@ public class InMemoryMenuRepositoryTests
     /// <summary>
     /// This test will run 100 operations concurrently to test concurrency issues
     /// </summary>
-    [Theory, AutoData]
+    [Theory, InMemoryMenuRepositoryAutoData]
     public async Task ParallelRunTest(InMemoryMenuRepository repository)
     {
         Task[] tasks = new Task[100];


### PR DESCRIPTION
Update templates to remove Cosmo / Dynamo specific tests if using InMemory. 
Create new AutoData for InMemoryMenuRepository to add customised ILogger.

#### 📲 What

Update templates to remove Cosmo / Dynamo specific tests if using InMemory. 
Create new AutoData for InMemoryMenuRepository to add customised ILogger.

#### 🤔 Why

When creating a barebones project without any database there were redundant unit tests which failed the build. 
The integration tests failed because of a lack of ILogger implementation in the InMemory AutoData.

#### 🛠 How

More in-depth discussion of the change or implementation.

#### 👀 Evidence

Screenshots / external resources / links / etc.
Link to documentation updated with changes impacted in the PR

#### 🕵️ How to test

Notes for QA

#### ✅ Acceptance criteria Checklist

- [ ] Code peer reviewed?
- [ ] Documentation has been updated to reflect the changes?
- [ ] Passing all automated tests, including a successful deployment?
- [ ] Passing any exploratory testing?
- [ ] Rebased/merged with latest changes from development and re-tested?
- [ ] Meeting the Coding Standards?
